### PR TITLE
Storing the best agent index at each iteration

### DIFF
--- a/opytimizer/core/optimizer.py
+++ b/opytimizer/core/optimizer.py
@@ -88,13 +88,14 @@ class Optimizer:
         """
 
         # Iterate through all agents
-        for agent in space.agents:
+        for idx, agent in enumerate(space.agents):
             # Calculate the fitness value of current agent
             agent.fit = function.pointer(agent.position)
             
             # If agent's fitness is better than global fitness
             if agent.fit < space.best_agent.fit:
                 # Makes a deep copy of current agent to the best agent
+                space.best_index = idx
                 space.best_agent.position = copy.deepcopy(agent.position)
                 space.best_agent.fit = copy.deepcopy(agent.fit)
 

--- a/opytimizer/core/space.py
+++ b/opytimizer/core/space.py
@@ -46,6 +46,9 @@ class Space:
         # Best agent object
         self._best_agent = None
 
+        # Index of the best agent. Initially the first agent is the best one
+        self._best_index = 0
+
         # Lower bounds
         self._lb = np.zeros(n_variables)
 
@@ -110,6 +113,17 @@ class Space:
     @best_agent.setter
     def best_agent(self, best_agent):
         self._best_agent = best_agent
+
+    @property
+    def best_index(self):
+        """int: Index of the agent that achieved the lowest fitness value.
+
+        """
+        return self._best_index
+
+    @best_index.setter
+    def best_index(self, best_index):
+        self._best_index = best_index
 
     @property
     def lb(self):

--- a/opytimizer/optimizers/abc.py
+++ b/opytimizer/optimizers/abc.py
@@ -281,7 +281,7 @@ class ABC(Optimizer):
             self._evaluate(space, function)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/aiwpso.py
+++ b/opytimizer/optimizers/aiwpso.py
@@ -1,8 +1,5 @@
-import copy
-
 import numpy as np
 
-import opytimizer.math.random as r
 import opytimizer.utils.history as h
 import opytimizer.utils.logging as l
 from opytimizer.optimizers.pso import PSO
@@ -172,7 +169,7 @@ class AIWPSO(PSO):
             self._compute_success(space.agents, fitness)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/ba.py
+++ b/opytimizer/optimizers/ba.py
@@ -304,7 +304,7 @@ class BA(Optimizer):
             self._evaluate(space, function)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/bha.py
+++ b/opytimizer/optimizers/bha.py
@@ -177,7 +177,7 @@ class BHA(Optimizer):
             self._evaluate(space, function)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/cs.py
+++ b/opytimizer/optimizers/cs.py
@@ -278,7 +278,7 @@ class CS(Optimizer):
             self._evaluate(space, function)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/fa.py
+++ b/opytimizer/optimizers/fa.py
@@ -194,7 +194,7 @@ class FA(Optimizer):
             self._evaluate(space, function)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/fpa.py
+++ b/opytimizer/optimizers/fpa.py
@@ -1,7 +1,5 @@
 import copy
 
-import numpy as np
-
 import opytimizer.math.distribution as d
 import opytimizer.math.random as r
 import opytimizer.utils.history as h
@@ -248,7 +246,7 @@ class FPA(Optimizer):
             self._evaluate(space, function)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/hs.py
+++ b/opytimizer/optimizers/hs.py
@@ -1,7 +1,5 @@
 import copy
 
-import numpy as np
-
 import opytimizer.math.random as r
 import opytimizer.utils.history as h
 import opytimizer.utils.logging as l
@@ -219,7 +217,7 @@ class HS(Optimizer):
             self._evaluate(space, function)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/ihs.py
+++ b/opytimizer/optimizers/ihs.py
@@ -165,7 +165,7 @@ class IHS(HS):
             self._evaluate(space, function)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/pso.py
+++ b/opytimizer/optimizers/pso.py
@@ -256,7 +256,7 @@ class PSO(Optimizer):
             self._evaluate(space, function, local_position)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/optimizers/wca.py
+++ b/opytimizer/optimizers/wca.py
@@ -262,7 +262,7 @@ class WCA(Optimizer):
             self.d_max -= (self.d_max / space.n_iterations)
 
             # Every iteration, we need to dump the current space agents
-            history.dump(space.agents, space.best_agent)
+            history.dump(space.agents, space.best_agent, space.best_index)
 
             logger.info(f'Fitness: {space.best_agent.fit}')
             logger.info(f'Position: {space.best_agent.position}')

--- a/opytimizer/utils/history.py
+++ b/opytimizer/utils/history.py
@@ -44,28 +44,21 @@ class History:
     def best_agent(self, best_agent):
         self._best_agent = best_agent
 
-    def dump(self, agents, best_agent):
+    def dump(self, agents, best_agent, best_index=0):
         """Dumps agents and best agent into the object
 
         Args:
             agents (list): List of agents.
             best_agent (Agent): An instance of the best agent.
-
+            best_index (Optional int): Index of the agent that is currently the best one.
         """
 
-        # Declaring an auxiliary empty list
-        a = []
-
-        # For each agent
-        for agent in agents:
-            # We append its position as a list and its fitness
-            a.append((agent.position.tolist(), agent.fit))
-
-        # Finally, we can append the current iteration agents to our property
+        # Recording position and fitness for each agent
+        a = [(agent.position.tolist(), agent.fit) for agent in agents]
         self.agents.append(a)
 
         # Appending the best agent as well
-        self.best_agent.append((best_agent.position.tolist(), best_agent.fit))
+        self.best_agent.append((best_agent.position.tolist(), best_agent.fit, best_index))
 
     def show(self):
         """Prints in a formatted way the history of agents' and best agent's 
@@ -91,14 +84,8 @@ class History:
 
         """
 
-        # Opening the file in write mode
-        f = open(file_name, 'wb')
-
-        # Dumps to a pickle file
-        pickle.dump(self, f)
-
-        # Close the file
-        f.close()
+        with open(file_name, 'wb') as dest_file:
+            pickle.dump(self, dest_file)
 
     def load(self, file_name):
         """Loads the object from a pickle encoding.
@@ -108,11 +95,7 @@ class History:
 
         """
 
-        # Opens the desired file in read mode
-        f = open(file_name, "rb")
-
-        # Loads using pickle
-        h = pickle.load(f)
-
         # Resetting current object state to loaded state
-        self.__dict__.update(h.__dict__)
+        with open(file_name, "rb") as origin_file:
+            h = pickle.load(origin_file)
+            self.__dict__.update(h.__dict__)

--- a/tests/opytimizer/utils/test_history.py
+++ b/tests/opytimizer/utils/test_history.py
@@ -41,10 +41,11 @@ def test_history_dump():
     for _ in range(5):
         agents.append(agent.Agent(n_variables=2, n_dimensions=1))
 
-    new_history.dump(agents, agents[0])
+    new_history.dump(agents, agents[4], 4)
 
     assert len(new_history.agents) > 0
     assert len(new_history.best_agent) > 0
+    assert new_history.best_agent[0][-1] == 4
 
 
 def test_history_show():


### PR DESCRIPTION
This PR proposes storing the index (i.e. the number of the agent) that achieved the best fitness value during each iteration. This allows the user to recover information stored by the agents in the disk after the optimization procedure, for instance, to reload the top `k`best neural networks.

Previously `history.best` returned a list of tuples in the format `[(agent-finess_0, agent-position_0), ... (agent-fitness_n, agent-position_n)]`. This PR replaces this format by `[(agent-finess_0, agent-position_0, agent-index_n), ... (agent-fitness_n, agent-position_n, agent-index_n)]`, thus mantaining backward compatibility.

Further, some unused imports were also removed.