### PR TITLE
Fix import when building docs (clean chroot)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,10 +17,10 @@ import sys
 
 import sphinx_rtd_theme
 
+# This step ensures that the source package is imported
+sys.path.insert(0, os.path.abspath("../"))
+
 import opytimizer
-
-sys.path.insert(0, os.path.abspath("."))
-
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Docs can now be built in a clean chroot. Previous settings needed to be corrected